### PR TITLE
v1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0 (March 2nd, 2017)
+
+- Make programs not wait the full 5 second HTTP Timeout on panic.
+
 ## 1.3.0 (March 2nd, 2017)
 
 - Made Context Lines an optional feature that are enabled by default.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentry-rs"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Eric Coan <ecoan@instructure.com>"]
 description = "A Sentry Client for Rust Lang."
 license = "MIT"


### PR DESCRIPTION
fixes #1 

**Summary**

- Uses Channels so we don't have to wait for the full HTTP Timeout, even when it doesn't occur.

**Test Plan**

- `cargo test` works.
- On a program that panics (after a panic handler has been registered) it doesn't take 5 seconds to close, The event still goes to sentry.
