### PR TITLE
v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1 (March 12th, 2017)
+
+- Fixed context line being one off.
+
 ## 1.5.0 (March 12th, 2017)
 
 - Added "in app" field to stacktraces to quickly get you to your apps errors.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentry-rs"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Eric Coan <ecoan@instructure.com>"]
 description = "A Sentry Client for Rust Lang."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl Sentry {
             if f.is_ok() {
               let file = f.unwrap();
               let buffed_reader = BufReader::new(&file);
-              let items = buffed_reader.lines().skip((lineno - 5) as usize).take(11);
+              let items = buffed_reader.lines().skip((lineno - 6) as usize).take(11);
 
               let mut i = 0;
               for item in items {


### PR DESCRIPTION
**Summary**

Fixes the context line actually being placed one off, due to a math error on my part.

**Test Plan**

- All tests pass.
- In sentry the correct context line is shown.
