### PR TITLE
2.0, sentrycredentials url parsing, custom devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (March 29th, 2017)
+
+- Allowed Specifying of Devices (Breaking Change). Still defaults to the same.
+- Allowed parsing of the sentry credentials from a raw dsn string.
+- Allowed you to compare equality of all models.
+
 ## 1.5.1 (March 12th, 2017)
 
 - Fixed context line being one off.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentry-rs"
-version = "1.5.1"
+version = "2.0.0"
 authors = ["Eric Coan <ecoan@instructure.com>"]
 description = "A Sentry Client for Rust Lang."
 license = "MIT"
@@ -16,6 +16,7 @@ hyper-native-tls = "0.2"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
+url = "1"
 
 [features]
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your rusts `Cargo.toml`:
 
 ```toml
 [dependencies]
-sentry-rs = "1.5"
+sentry-rs = "2"
 ```
 
 And then this in your crate root:

--- a/examples/cross-threads.rs
+++ b/examples/cross-threads.rs
@@ -24,10 +24,10 @@ fn main() {
   let other_sentry_two = sentry.clone();
 
   let thread_one = thread::spawn(move || {
-    other_sentry_one.info("thread.one", "Test Message", None);
+    other_sentry_one.info("thread.one", "Test Message", None, None);
   });
   let thread_two = thread::spawn(move || {
-    other_sentry_two.info("thread.two", "Message Test", None);
+    other_sentry_two.info("thread.two", "Message Test", None, None);
   });
 
   let _ = thread_one.join();

--- a/examples/logger-demo.rs
+++ b/examples/logger-demo.rs
@@ -18,6 +18,6 @@ fn main() {
     credentials
   );
 
-  // Logger Name, Message to Log, Potential Culprit (Option<&str>).
-  sentry.info("Logger Name", "Message To Log", None);
+  // Logger Name, Message to Log, Potential Culprit (Option<&str>), Device (Option<Device>).
+  sentry.info("Logger Name", "Message To Log", None, None);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate serde;
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
+extern crate url;
 
 pub mod models;
 pub mod workers;
@@ -237,7 +238,8 @@ impl Sentry {
                              Some(&server_name),
                              Some(frames),
                              Some(&release),
-                             Some(&environment));
+                             Some(&environment),
+                             None);
       let recv = the_rec.lock();
       if recv.is_err() {
         std::thread::sleep(Duration::from_secs(5));
@@ -269,28 +271,28 @@ impl Sentry {
   }
 
   /// Logs a fatal message to sentry.
-  pub fn fatal(&self, logger: &str, message: &str, culprit: Option<&str>) {
-    self.log(logger, "fatal", message, culprit, None);
+  pub fn fatal(&self, logger: &str, message: &str, culprit: Option<&str>, device: Option<Device>) {
+    self.log(logger, "fatal", message, culprit, None, device);
   }
 
   /// Logs an error message to sentry.
-  pub fn error(&self, logger: &str, message: &str, culprit: Option<&str>) {
-    self.log(logger, "error", message, culprit, None);
+  pub fn error(&self, logger: &str, message: &str, culprit: Option<&str>, device: Option<Device>) {
+    self.log(logger, "error", message, culprit, None, device);
   }
 
   /// Logs a warning message to sentry.
-  pub fn warning(&self, logger: &str, message: &str, culprit: Option<&str>) {
-    self.log(logger, "warning", message, culprit, None);
+  pub fn warning(&self, logger: &str, message: &str, culprit: Option<&str>, device: Option<Device>) {
+    self.log(logger, "warning", message, culprit, None, device);
   }
 
   /// Logs an info message to sentry.
-  pub fn info(&self, logger: &str, message: &str, culprit: Option<&str>) {
-    self.log(logger, "info", message, culprit, None);
+  pub fn info(&self, logger: &str, message: &str, culprit: Option<&str>, device: Option<Device>) {
+    self.log(logger, "info", message, culprit, None, device);
   }
 
   /// Logs a debug message to sentry.
-  pub fn debug(&self, logger: &str, message: &str, culprit: Option<&str>) {
-    self.log(logger, "debug", message, culprit, None);
+  pub fn debug(&self, logger: &str, message: &str, culprit: Option<&str>, device: Option<Device>) {
+    self.log(logger, "debug", message, culprit, None, device);
   }
 
   /// Handles a log call of any level.
@@ -299,7 +301,8 @@ impl Sentry {
          level: &str,
          message: &str,
          culprit: Option<&str>,
-         fingerprint: Option<Vec<String>>) {
+         fingerprint: Option<Vec<String>>,
+         device: Option<Device>) {
 
     let fpr = match fingerprint {
       Some(f) => f,
@@ -318,6 +321,7 @@ impl Sentry {
                                              Some(&self.server_name),
                                              None,
                                              Some(&self.release),
-                                             Some(&self.environment)));
+                                             Some(&self.environment),
+                                             device));
   }
 }

--- a/tests/models_test.rs
+++ b/tests/models_test.rs
@@ -116,3 +116,35 @@ pub fn prep_string_cuts_off_string_in_quotes() {
 
   assert_eq!(finalized_string, "");
 }
+
+#[test]
+pub fn test_sentry_creds_parsing() {
+  let test_string = "https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY@ZZZZ/AAA"
+    .to_owned()
+    .parse::<SentryCredentials>();
+  assert!(test_string.is_ok());
+  let manual_creation = SentryCredentials {
+    key: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned(),
+    secret: "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned(),
+    host: Some("zzzz".to_owned()),
+    project_id: "AAA".to_owned()
+  };
+  assert_eq!(test_string.unwrap(), manual_creation);
+}
+
+#[test]
+pub fn test_sentry_creds_parsing_failure() {
+  let first_test_string = "https://sentry.io/aaa"
+    .to_owned()
+    .parse::<SentryCredentials>();
+  let second_test_string = "https://aaaaaa@sentry.io/aaa"
+    .to_owned()
+    .parse::<SentryCredentials>();
+  let third_test_string = "https://aaa:bbb@sentry.io/"
+    .to_owned()
+    .parse::<SentryCredentials>();
+
+  assert!(first_test_string.is_err());
+  assert!(second_test_string.is_err());
+  assert!(third_test_string.is_err());
+}


### PR DESCRIPTION
**Summary**

this commit bumps sentry-rs to 2.0 (breaking change :P)
this commit adds in:
  - The ability to parse sentry credentials through a URL.
  - The ability to specify a custom device, the default is the same.
  - Implements PartialEq/Eq traits for all structs.

**Test Plan**

- All tests pass.
- All examples work.
