### PR TITLE
make extra a serde_json::Value not string

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -93,7 +93,7 @@ pub struct Event {
   /// The modules of this event.
   pub modules: BTreeMap<String, String>,
   /// The extra info for this event.
-  pub extra: BTreeMap<String, String>,
+  pub extra: BTreeMap<String, serde_json::Value>,
   /// The fingerprints of this event.
   pub fingerprint: Vec<String>,
 }
@@ -156,10 +156,11 @@ impl Event {
     }
     let extra_len = self.extra.len();
     if extra_len > 0 {
-      value["extra"] = json!(self.extra);
+      value["extra"] = self.extra;
     }
     if let Some(ref stacktrace) = self.stacktrace {
-      let frames = stacktrace.iter()
+      let frames = stacktrace
+        .iter()
         .map(|item| json!(item))
         .collect::<Vec<Value>>();
       value["stacktrace"] = json!({
@@ -193,17 +194,18 @@ impl Event {
   /// Some(vec!["fingerprint".to_owned()]), Some("server name"), Some(vec![]),
   /// Some("release"), Some("production"), None);
   /// ```
-  pub fn new(logger: &str,
-             level: &str,
-             message: &str,
-             culprit: Option<&str>,
-             fingerprint: Option<Vec<String>>,
-             server_name: Option<&str>,
-             stacktrace: Option<Vec<StackFrame>>,
-             release: Option<&str>,
-             environment: Option<&str>,
-             device: Option<Device>)
-             -> Event {
+  pub fn new(
+    logger: &str,
+    level: &str,
+    message: &str,
+    culprit: Option<&str>,
+    fingerprint: Option<Vec<String>>,
+    server_name: Option<&str>,
+    stacktrace: Option<Vec<StackFrame>>,
+    release: Option<&str>,
+    environment: Option<&str>,
+    device: Option<Device>,
+  ) -> Event {
 
     Event {
       event_id: "".to_owned(),

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,7 +6,7 @@
 
 use chrono::offset::utc::UTC;
 use serde_json::{to_string, Value};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::str::FromStr;
 use url::Url;
@@ -93,7 +93,7 @@ pub struct Event {
   /// The modules of this event.
   pub modules: BTreeMap<String, String>,
   /// The extra info for this event.
-  pub extra: BTreeMap<String, Value>,
+  pub extra: HashMap<String, Value>,
   /// The fingerprints of this event.
   pub fingerprint: Vec<String>,
 }
@@ -156,7 +156,7 @@ impl Event {
     }
     let extra_len = self.extra.len();
     if extra_len > 0 {
-      value["extra"] = self.extra;
+      value["extra"] = json!(self.extra);
     }
     if let Some(ref stacktrace) = self.stacktrace {
       let frames = stacktrace

--- a/src/models.rs
+++ b/src/models.rs
@@ -57,7 +57,7 @@ pub struct Device {
   pub build: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 /// An Event that gets sent to Sentry. Each attribute is described in detail [HERE].
 ///
 /// [HERE]: https://docs.sentry.io/clientdev/attributes/
@@ -232,7 +232,7 @@ impl Event {
       tags: BTreeMap::new(),
       environment: environment.map(|c| c.to_owned()),
       modules: BTreeMap::new(),
-      extra: BTreeMap::new(),
+      extra: HashMap::new(),
       fingerprint: fingerprint.unwrap_or(vec![]),
     }
   }
@@ -328,7 +328,7 @@ impl FromStr for SentryCredentials {
     }
     let potential_password = parsed.password();
     if potential_password.is_none() {
-      /// The "password" is equal to the API Secret for Sentry Credentials.
+      // The "password" is equal to the API Secret for Sentry Credentials.
       return Err(CredentialsParseError::NoApiSecret);
     }
     let potential_hostname = parsed.host_str();

--- a/src/models.rs
+++ b/src/models.rs
@@ -93,7 +93,7 @@ pub struct Event {
   /// The modules of this event.
   pub modules: BTreeMap<String, String>,
   /// The extra info for this event.
-  pub extra: BTreeMap<String, serde_json::Value>,
+  pub extra: BTreeMap<String, Value>,
   /// The fingerprints of this event.
   pub fingerprint: Vec<String>,
 }

--- a/tests/models_test.rs
+++ b/tests/models_test.rs
@@ -1,7 +1,9 @@
 extern crate sentry_rs;
+#[macro_use]
+extern crate serde_json;
 
 use sentry_rs::models::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 pub fn generate_shallow_event() -> Event {
   Event {
@@ -27,7 +29,7 @@ pub fn generate_shallow_event() -> Event {
     tags: BTreeMap::new(),
     environment: None,
     modules: BTreeMap::new(),
-    extra: BTreeMap::new(),
+    extra: HashMap::new(),
     fingerprint: vec![],
   }
 }
@@ -39,9 +41,9 @@ pub fn generate_full_event() -> Event {
   let mut modules = BTreeMap::new();
   modules.insert("module_key".to_owned(), "module_value".to_owned());
   modules.insert("module_key_2".to_owned(), "module_value_2".to_owned());
-  let mut extras = BTreeMap::new();
-  extras.insert("extra_key".to_owned(), "extra_value".to_owned());
-  extras.insert("extra_key_2".to_owned(), "extra_value_2".to_owned());
+  let mut extras = HashMap::new();
+  extras.insert("extra_key".to_owned(), json!("extra_value"));
+  extras.insert("extra_key_2".to_owned(), json!("extra_value_2"));
   Event {
     event_id: "event_id".to_owned(),
     message: "message".to_owned(),
@@ -67,14 +69,14 @@ pub fn generate_full_event() -> Event {
         lineno: 10,
         pre_context: vec![
           "filename: \"filename.stack.frame\".to_owned()".to_owned(),
-          "function: \"function.stack.frame\".to_owned()".to_owned()
+          "function: \"function.stack.frame\".to_owned()".to_owned(),
         ],
         context_line: "context_line: \"context_line\"".to_owned(),
         post_context: vec![
           "filename: \"filename.stack.frame\".to_owned()".to_owned(),
-          "function: \"function.stack.frame\".to_owned()".to_owned()
+          "function: \"function.stack.frame\".to_owned()".to_owned(),
         ],
-        in_app: true
+        in_app: true,
       },
       StackFrame {
         filename: "filename.2.stack.frame".to_owned(),
@@ -83,7 +85,7 @@ pub fn generate_full_event() -> Event {
         pre_context: Vec::new(),
         context_line: "".to_owned(),
         post_context: Vec::new(),
-        in_app: false
+        in_app: false,
       },
     ]),
     release: Some("Release".to_owned()),
@@ -91,9 +93,7 @@ pub fn generate_full_event() -> Event {
     environment: Some("environment".to_owned()),
     modules: modules,
     extra: extras,
-    fingerprint: vec![
-      "fingerprint".to_owned()
-    ],
+    fingerprint: vec!["fingerprint".to_owned()],
   }
 }
 
@@ -127,7 +127,7 @@ pub fn test_sentry_creds_parsing() {
     key: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned(),
     secret: "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned(),
     host: Some("zzzz".to_owned()),
-    project_id: "AAA".to_owned()
+    project_id: "AAA".to_owned(),
   };
   assert_eq!(test_string.unwrap(), manual_creation);
 }


### PR DESCRIPTION
Pretty straightforward. Sentry accepts JSON objects as values in `extra`, so let users provide JSON objects instead of forcing them to provide a string