### PR TITLE
add scheme to SentryCredentials

### DIFF
--- a/examples/cross-threads.rs
+++ b/examples/cross-threads.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 fn main() {
   let credentials = SentryCredentials {
+    scheme: env::var("SENTRY_SCHEME").unwrap_or("https".to_owned()),
     key: env::var("SENTRY_KEY").unwrap_or("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned()),
     secret: env::var("SENTRY_SECRET").unwrap_or("YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned()),
     host: Some(env::var("SENTRY_HOST").unwrap_or("app.getsentry.com".to_owned())),

--- a/examples/logger-demo.rs
+++ b/examples/logger-demo.rs
@@ -6,6 +6,7 @@ use std::env;
 
 fn main() {
   let credentials = SentryCredentials {
+    scheme: env::var("SENTRY_SCHEME").unwrap_or("https".to_owned()),
     key: env::var("SENTRY_KEY").unwrap_or("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned()),
     secret: env::var("SENTRY_SECRET").unwrap_or("YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned()),
     host: Some(env::var("SENTRY_HOST").unwrap_or("app.getsentry.com".to_owned())),

--- a/examples/panic-handler-demo.rs
+++ b/examples/panic-handler-demo.rs
@@ -6,6 +6,7 @@ use std::{ env, thread };
 
 fn main() {
   let credentials = SentryCredentials {
+    scheme: env::var("SENTRY_SCHEME").unwrap_or("https".to_owned()),
     key: env::var("SENTRY_KEY").unwrap_or("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned()),
     secret: env::var("SENTRY_SECRET").unwrap_or("YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned()),
     host: Some(env::var("SENTRY_HOST").unwrap_or("app.getsentry.com".to_owned())),

--- a/src/models.rs
+++ b/src/models.rs
@@ -274,6 +274,7 @@ impl Event {
 ///
 /// fn main() {
 ///   let credentials = SentryCredentials {
+///     scheme: env::var("SENTRY_SCHEME").unwrap_or("https".to_owned()),
 ///     key: env::var("SENTRY_KEY").unwrap_or("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned()),
 ///     secret: env::var("SENTRY_SECRET").unwrap_or("YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned()),
 ///     host: Some(env::var("SENTRY_HOST").unwrap_or("sentry.io".to_owned())),
@@ -296,6 +297,7 @@ impl Event {
 /// }
 /// ```
 pub struct SentryCredentials {
+  pub scheme: String,
   pub key: String,
   pub secret: String,
   pub host: Option<String>,
@@ -321,6 +323,7 @@ impl FromStr for SentryCredentials {
       return Err(CredentialsParseError::BadUrl);
     }
     let parsed = attempt_parse.unwrap();
+    let scheme = parsed.scheme();
     let potential_username = parsed.username();
     if potential_username.is_empty() {
       // The "Username" is equal to the API Key for Sentry Credentials.
@@ -344,6 +347,7 @@ impl FromStr for SentryCredentials {
       return Err(CredentialsParseError::NoProjectId);
     }
     Ok(SentryCredentials {
+      scheme: scheme.to_owned(),
       key: potential_username.to_owned(),
       secret: potential_password.unwrap().to_owned(),
       host: Some(potential_hostname.unwrap().to_owned()),

--- a/tests/models_test.rs
+++ b/tests/models_test.rs
@@ -124,6 +124,7 @@ pub fn test_sentry_creds_parsing() {
     .parse::<SentryCredentials>();
   assert!(test_string.is_ok());
   let manual_creation = SentryCredentials {
+    scheme: "https".to_owned(),
     key: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned(),
     secret: "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned(),
     host: Some("zzzz".to_owned()),


### PR DESCRIPTION
**Summary**

- [x] add scheme to SentryCredentials

Our sentry service doesn't have https support, so I add the `scheme` to `SentryCredentials`.

**Test Plan**

- [x] cargo test?
