### PR TITLE
Added logging submodule containing a `SentryLogger` struct

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ test_script:
   - cargo run --example cross-threads
   - cargo run --example logger-demo
   - cargo run --example panic-handler-demo
+  - cargo run --example log-macro-demo
 
 ## Notifications ##
 notifications:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 version: 2
 executorType: docker
 containerInfo:
-  - image: jimmycuadra/rust:latest
+  - image: rust:latest
 stages:
   build:
     workDir: /source
@@ -29,3 +29,6 @@ stages:
       - type: shell
         shell: /bin/bash
         command: cargo run --example panic-handler-demo
+      - type: shell
+        shell: /bin/bash
+        command: cargo run --example log-macro-demo

--- a/examples/log-macro-demo.rs
+++ b/examples/log-macro-demo.rs
@@ -1,0 +1,25 @@
+extern crate sentry_rs;
+#[macro_use]
+extern crate log;
+
+use sentry_rs::models::SentryCredentials;
+use sentry_rs::Sentry;
+use sentry_rs::logging::SentryLogger;
+use std::env;
+
+fn main() {
+  let dsn = "https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY@sentry.io/XX";
+  let credentials = SentryCredentials::from_str(dsn).unwrap();
+  let sentry = Sentry::new(
+    "Server Name".to_string(),
+    "Release of Your Project Consider using env!()".to_string(),
+    "Environment you're deployed in".to_string(),
+    credentials,
+  );
+
+  SentryLogger::init(sentry, "default logger", log::Level::Warn);
+  debug!("This debug message won't be logged to Sentry.");
+  info!("This info message won't be logged to Sentry.");
+  warn!("This warn message should be logged to Sentry.");
+  error!("This error message should be logged to Sentry.");
+}

--- a/examples/log-macro-demo.rs
+++ b/examples/log-macro-demo.rs
@@ -8,8 +8,13 @@ use sentry_rs::logging::SentryLogger;
 use std::env;
 
 fn main() {
-  let dsn = "https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY@sentry.io/XX";
-  let credentials = SentryCredentials::from_str(dsn).unwrap();
+  let credentials = SentryCredentials {
+    scheme: env::var("SENTRY_SCHEME").unwrap_or("https".to_owned()),
+    key: env::var("SENTRY_KEY").unwrap_or("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_owned()),
+    secret: env::var("SENTRY_SECRET").unwrap_or("YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_owned()),
+    host: Some(env::var("SENTRY_HOST").unwrap_or("app.getsentry.com".to_owned())),
+    project_id: env::var("SENTRY_PROJECT_ID").unwrap_or("XX".to_owned()),
+  };
   let sentry = Sentry::new(
     "Server Name".to_string(),
     "Release of Your Project Consider using env!()".to_string(),
@@ -17,7 +22,7 @@ fn main() {
     credentials,
   );
 
-  SentryLogger::init(sentry, "default logger", log::Level::Warn);
+  SentryLogger::init(sentry, "default logger".to_string(), log::Level::Warn);
   debug!("This debug message won't be logged to Sentry.");
   info!("This info message won't be logged to Sentry.");
   warn!("This warn message should be logged to Sentry.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod models;
 pub mod reactor;
 pub mod request;
 pub mod workers;
+pub mod logging;
 
 use models::*;
 use request::DispatchRequest;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,69 @@
+//! Logging related utilities.
+
+use log::{self, Log, Record, Level, Metadata, SetLoggerError};
+
+use super::Sentry;
+
+/// Logger which implements the `log::Log` trait. This allows logging via the
+/// macros defined in the `log` crate.
+pub struct SentryLogger {
+  // Sentry client used for delivering log messages.
+  sentry: Sentry,
+
+  // Name of the logger to log messages with.
+  logger_name: String,
+
+  // Minimum level to log messages to Sentry at.
+  level: Level,
+}
+
+impl SentryLogger {
+  /// Construct a new `SentryLogger`.
+  ///
+  /// # Arguments
+  ///
+  /// * `sentry` - Sentry client used to deliver log messages.
+  /// * `logger_name` - String used as logger name in messages.
+  /// * `level` - Minimum level to log messages to Sentry at.
+  pub fn new(sentry: Sentry, logger_name: &str, level: Level) -> Self {
+    SentryLogger {
+      sentry,
+      logger_name: logger_name.to_owned(),
+      level
+    }
+  }
+
+  /// Globally initialises a `SentryLogger` as the log facility. This will then be used by the
+  /// `log` module's logging macros (e.g. `debug!`, `info!`, etc.).
+  ///
+  /// # Arguments
+  ///
+  /// * `sentry` - Sentry client used to deliver log messages.
+  /// * `logger_name` - String used as logger name in messages.
+  /// * `level` - Minimum level to log messages to Sentry at.
+  pub fn init(sentry: Sentry, logger_name: &str, level: Level) -> Result<(), SetLoggerError> {
+      log::set_max_level(level.to_level_filter());
+      log::set_boxed_logger(Box::new(SentryLogger::new(sentry, logger_name, level)))
+  }
+}
+
+impl Log for SentryLogger {
+  fn enabled(&self, metadata: &Metadata) -> bool {
+    metadata.level() <= self.level
+  }
+
+  fn log(&self, record: &Record) {
+    let metadata = record.metadata();
+    if self.enabled(metadata) {
+      match metadata.level() {
+        Level::Error => self.sentry.error(&self.logger_name, &format!("{}", record.args()), None, None),
+        Level::Warn => self.sentry.warning(&self.logger_name, &format!("{}", record.args()), None, None),
+        Level::Info => self.sentry.info(&self.logger_name, &format!("{}", record.args()), None, None),
+        Level::Debug => self.sentry.debug(&self.logger_name, &format!("{}", record.args()), None, None),
+        _ => (), // client doesn't support logging at Trace level
+      }
+    }
+  }
+
+  fn flush(&self) {}
+}


### PR DESCRIPTION
** Summary **

Adds a `SentryLogger` struct that implements the `log::Log` trait.

This allows for logging to Sentry using the macros provided by the `log`
crate, e.g. `debug!("foo")`, `error!("Thing failed: {}", thing)` etc.

I'm working separately on a simple logger which combines multiple loggers, and am currently using it to enable logging to both Sentry (using this module) and to stdout/stderr (using `env_logger`) using the same `log` macros.

**Test Plan**

I've added a file to `examples/log-macro-demo.rs` which shows usage, and can be used for testing.